### PR TITLE
Deliberately fail eslint

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-}
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;
+module.exports = {
+  eslint: {
+    ignoreDuringBuilds: true
+  }
+};

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,6 @@ const nextConfig = {
 module.exports = nextConfig;
 module.exports = {
   eslint: {
-    ignoreDuringBuilds: true
+    ignoreDuringBuilds: true // otherwise linting errors will fail and stop builds, affecting deployments.
   }
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head";
 import Image from "next/image";
 import { Inter } from "next/font/google";
-import styles from "@/styles/Home.module.css";
+import styles from "@/styles/Home.module.css"
 
 const inter = Inter({ subsets: ["latin"] });
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import Head from "next/head";
 import Image from "next/image";
 import { Inter } from "next/font/google";
-import styles from "@/styles/Home.module.css"
+import styles from "@/styles/Home.module.css";
 
 const inter = Inter({ subsets: ["latin"] });
 


### PR DESCRIPTION
As it stands, ESLint runs during build. If there are any outstanding ESLint errors, the build will fail. This will fail any deployment.

Change the next config file to skip linting during build. Linting should be restricted to development and the CI pipeline.