### PR TITLE
Production db deploys on merge

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -9,6 +9,8 @@ jobs:
   deploy-production:
     permissions: write-all
     runs-on: ubuntu-latest
+    environment:
+      name: production
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -3,7 +3,7 @@ name: Deploy Production
 on:
   push:
     branches:
-      - "production_db_deploys_on_merge"
+      - "master"
 
 jobs:
   deploy-production:

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Run Prisma Migrate
         run: |
           touch .env
-          echo DATABASE_URL="${{ secrets.DATABASE_URL}}" >> .env
-          echo DIRECT_DATABASE_URL="${{ secrets.DIRECT_DATABASE_URL}}" >> .env
+          echo DATABASE_URL="${{ secrets.DATABASE_URL_LIVE_POOLED}}" >> .env
+          echo DIRECT_DATABASE_URL="${{ secrets.DATABASE_URL_LIVE_DIRECT}}" >> .env
           npx prisma migrate deploy

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -1,0 +1,26 @@
+name: Deploy Production
+
+on:
+  push:
+    branches:
+      - "production_db_deploys_on_merge"
+
+jobs:
+  deploy-production:
+    permissions: write-all
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Get last commit SHA
+        id: get_sha
+        run: |
+          echo sha="${{ github.event.before }}" | cut -c1-8 >> $GITHUB_OUTPUT
+
+      - name: Run Prisma Migrate
+        run: |
+          touch .env
+          echo DATABASE_URL="${{ secrets.DATABASE_URL}}" >> .env
+          echo DIRECT_DATABASE_URL="${{ secrets.DIRECT_DATABASE_URL}}" >> .env
+          npx prisma migrate deploy

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -21,6 +21,11 @@ jobs:
       - name: Run Prisma Migrate
         run: |
           touch .env
+          echo '.env before'
+          cat .env
           echo DATABASE_URL="${{ secrets.DATABASE_URL_LIVE_POOLED}}" >> .env
           echo DIRECT_DATABASE_URL="${{ secrets.DATABASE_URL_LIVE_DIRECT}}" >> .env
+          echo '.env after'
+          cat .env
+          echo 'about to pmd'
           npx prisma migrate deploy


### PR DESCRIPTION
### What I've done

On push to or PR merge with master, database changes are deployed.

### Screenshot (desktop and mobile)

### How I've done it

Create a new Github Actions workflow that is triggered on push to or PR merge with master:
- Checkout lastest code
- Runs npx prisma migrate deploy to run a migration on the live database
- Github actions secrets point to production database

### Why I've done it

So that PR merge results in automatic deployment of database in addition to project code.
